### PR TITLE
Pin Kafka version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,12 +70,13 @@ subprojects {
         set("mockitoVersion", "4.8.0")          // https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
         set("hamcrestVersion", "2.2")           // https://mvnrepository.com/artifact/org.hamcrest/hamcrest-core
 
-        set("kafkaVersion", "3.3.0")            // https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients
+        set("kafkaVersion", "3.3.1")            // https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients
     }
 
     val creekVersion : String by extra
     val guavaVersion : String by extra
     val log4jVersion : String by extra
+    val kafkaVersion : String by extra
     val junitVersion: String by extra
     val junitPioneerVersion: String by extra
     val mockitoVersion: String by extra
@@ -93,6 +94,15 @@ subprojects {
         testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
         testImplementation("org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+    }
+
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.apache.kafka") {
+                // Need a known Kafka version for module patching to work:
+                useVersion(kafkaVersion)
+            }
+        }
     }
 
     tasks.compileJava {


### PR DESCRIPTION
Regardless of what version of Kafka clients upstream dependencies bring in, we need the project to be at a known Kafka version so that the module patching works, i.e.

```kotlin
modularity.patchModule("kafka.streams", "kafka-streams-test-utils-$kafkaVersion.jar")
```

If we don't pin, this will break when creek-kafka is released with different version of Kafka jars.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended