### PR TITLE
Fix username in docker images

### DIFF
--- a/.creek/bootstrap.sh
+++ b/.creek/bootstrap.sh
@@ -84,8 +84,10 @@ echo "Updating module names to have prefix: $modNamePrefix"
 replaceInCode "example.mod" "$modNamePrefix"
 
 if [ "$repoUser" != "creek-service" ]; then
-  echo Updating repo user
+  echo "Updating repo user to $repoUser"
   replaceInCode "maven.pkg.github.com/creek-service/" "maven.pkg.github.com/$repoUser/"
+  replaceInCode "ghcr.io/creek-service/" "ghcr.io/$repoUser/"
+  replaceInCode "github.com/creek-service/" "github.com/$repoUser/"
 fi
 
 echo Deleting Creek specific code

--- a/.creek/bootstrap.sh
+++ b/.creek/bootstrap.sh
@@ -66,6 +66,13 @@ find . -type d -empty -delete
 echo Removing test expectation
 echo "Topologies:" > example-service/src/test/resources/kafka/streams/expected_topology.txt
 
+if [ "$repoUser" != "creek-service" ]; then
+  echo "Updating repo user to $repoUser"
+  replaceInCode "maven.pkg.github.com/creek-service/" "maven.pkg.github.com/$repoUser/"
+  replaceInCode "ghcr.io/creek-service/" "ghcr.io/${repoUser:l}/"
+  replaceInCode "github.com/creek-service/" "github.com/$repoUser/"
+fi
+
 echo "Updating repo name to: $repoName"
 replaceInCode "creek-service/aggregate-template" "$repoUserAndName"
 replaceInCode "aggregate-template" "${(L)${repoName}}"
@@ -82,13 +89,6 @@ replaceInCode "group = \"org.creekservice\"" "group = \"$groupName\""
 
 echo "Updating module names to have prefix: $modNamePrefix"
 replaceInCode "example.mod" "$modNamePrefix"
-
-if [ "$repoUser" != "creek-service" ]; then
-  echo "Updating repo user to $repoUser"
-  replaceInCode "maven.pkg.github.com/creek-service/" "maven.pkg.github.com/$repoUser/"
-  replaceInCode "ghcr.io/creek-service/" "ghcr.io/${repoUser:l}/"
-  replaceInCode "github.com/creek-service/" "github.com/$repoUser/"
-fi
 
 echo Deleting Creek specific code
 sedCode "/.*init:remove.*/d"

--- a/.creek/bootstrap.sh
+++ b/.creek/bootstrap.sh
@@ -86,7 +86,7 @@ replaceInCode "example.mod" "$modNamePrefix"
 if [ "$repoUser" != "creek-service" ]; then
   echo "Updating repo user to $repoUser"
   replaceInCode "maven.pkg.github.com/creek-service/" "maven.pkg.github.com/$repoUser/"
-  replaceInCode "ghcr.io/creek-service/" "ghcr.io/$repoUser/"
+  replaceInCode "ghcr.io/creek-service/" "ghcr.io/${repoUser:l}/"
   replaceInCode "github.com/creek-service/" "github.com/$repoUser/"
 fi
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,4 +64,4 @@ jobs:
         run: |
           ./gradlew pushAppImage
           # Above is not failing, but is also not working... try manual
-          docker push ghcr.io/creekservice/aggregate-template-example-service:latest
+          docker push ghcr.io/creek-service/aggregate-template-example-service:latest

--- a/example-service/Dockerfile
+++ b/example-service/Dockerfile
@@ -3,6 +3,8 @@ ARG APP_NAME
 ARG APP_VERSION
 ENV VERSION=$APP_VERSION
 
+LABEL org.opencontainers.image.source=https://github.com/creek-service/aggregate-template
+
 RUN yum update -y
 RUN yum install -y tar lsof
 

--- a/example-service/build.gradle.kts
+++ b/example-service/build.gradle.kts
@@ -33,8 +33,8 @@ val buildAppImage = tasks.create("buildAppImage", DockerBuildImage::class) {
     dependsOn("prepareDocker")
     buildArgs.put("APP_NAME", project.name)
     buildArgs.put("APP_VERSION", "${project.version}")
-    images.add("ghcr.io/creekservice/${rootProject.name}-${project.name}:latest")
-    images.add("ghcr.io/creekservice/${rootProject.name}-${project.name}:${project.version}")
+    images.add("ghcr.io/creek-service/${rootProject.name}-${project.name}:latest")
+    images.add("ghcr.io/creek-service/${rootProject.name}-${project.name}:${project.version}")
 }
 
 tasks.register<Copy>("prepareDocker") {
@@ -61,6 +61,7 @@ tasks.register<Copy>("prepareDocker") {
 
 tasks.create("pushAppImage", DockerPushImage::class) {
     dependsOn("buildAppImage")
-    images.add("ghcr.io/creekservice/${rootProject.name}-${project.name}:latest")
-    images.add("ghcr.io/creekservice/${rootProject.name}-${project.name}:${project.version}")
+    images.add("ghcr.io/creek-service/${rootProject.name}-${project.name}:latest")
+    images.add("ghcr.io/creek-service/${rootProject.name}-${project.name}:${project.version}")
 }
+

--- a/services/src/main/java/org/acme/example/services/ExampleServiceDescriptor.java
+++ b/services/src/main/java/org/acme/example/services/ExampleServiceDescriptor.java
@@ -52,7 +52,7 @@ public final class ExampleServiceDescriptor implements ServiceDescriptor {
 
     @Override
     public String dockerImage() {
-        return "ghcr.io/creekservice/aggregate-template-example-service";
+        return "ghcr.io/creek-service/aggregate-template-example-service";
     }
 
     @Override


### PR DESCRIPTION
Correct the GitHub username used in Docker image names from `creekservice` to `creek-service`.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended