### PR TITLE
Cancel in-progress pages build if not a PR

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -14,6 +14,7 @@ permissions:
 # Allow one concurrent deployment
 concurrency:
   group: "${{ github.repository }}-pages"
+  cancel-in-progress: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
 
 jobs:
   build_pages:


### PR DESCRIPTION
Ensure pages are deployed correctly by cancelling any in-progress builds that are running due to a push, but don't cancel PR builds as that would stop PR branch protection rules from being met.


### Reviewer checklist
 - [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
 - [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
 - [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
 - [ ] Ensure any appropriate documentation has been added or amended
