### PR TITLE
Fix issue with concurrent pages build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,10 +11,10 @@ on:
 permissions:
   contents: read
 
-# Allow one concurrent deployment
+# Allow one concurrent deployment, per branch
 concurrency:
-  group: "${{ github.repository }}-pages"
-  cancel-in-progress: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+  group: "${{ github.repository }}-pages-${{ github.ref }}"
+  cancel-in-progress: true
 
 jobs:
   build_pages:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -13,7 +13,7 @@ permissions:
 
 # Allow one concurrent deployment, per branch
 concurrency:
-  group: "${{ github.repository }}-pages-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Previously, GitHub was cancelling any previous pages build, even though it should only have done so for pushs, not PR builds. (see https://github.com/orgs/community/discussions/49963)

Switch to including the Git ref in the concurrency group so that each branch builds independently.

This means pages builds to the `main` branch will be in-order, with any older builds being auto-cancelled.

While PR builds will build independently. With each PR in its own concurrency group. Older builds within the same PR will be cancelled, but the PR itself will always have its most recent pages build left to run.

### Reviewer checklist
- [ ] Read the [contributing guide](https://github.com/creek-service/.github/blob/main/CONTRIBUTING.md)
- [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended