### PR TITLE
Expose aggregate descriptor

### DIFF
--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,7 +1,13 @@
+import org.acme.example.api.ExampleAggregateDescriptor;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+
 module example.mod.api {
     requires transitive creek.kafka.metadata;
 
     exports org.acme.example.api;
     exports org.acme.example.internal to
             example.mod.services;
+
+    provides ComponentDescriptor with
+            ExampleAggregateDescriptor;
 }

--- a/api/src/main/resources/META-INF/services/org.creekservice.api.platform.metadata.ComponentDescriptor
+++ b/api/src/main/resources/META-INF/services/org.creekservice.api.platform.metadata.ComponentDescriptor
@@ -1,0 +1,17 @@
+#
+# Copyright 2022-2023 Creek Contributors (https://github.com/creek-service)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.acme.example.api.ExampleAggregateDescriptor

--- a/api/src/test/java/org/acme/example/api/ExampleAggregateDescriptorTest.java
+++ b/api/src/test/java/org/acme/example/api/ExampleAggregateDescriptorTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.acme.example.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.instanceOf;
+
+import java.util.List;
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.creekservice.api.platform.metadata.ComponentDescriptors;
+import org.junit.jupiter.api.Test;
+
+class ExampleAggregateDescriptorTest {
+
+    @Test
+    void shouldLoadDescriptor() {
+        final List<ComponentDescriptor> loaded = ComponentDescriptors.load();
+        assertThat(loaded, hasItem(instanceOf(ExampleAggregateDescriptor.class)));
+    }
+}


### PR DESCRIPTION
Previously, the aggregate descriptor existed, but was not exposed as `provides ComponentDescriptor`.

### Reviewer checklist
- [ ] Read the [contributing guide](https://github.com/creek-service/.github/blob/main/CONTRIBUTING.md)
- [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended