### PR TITLE
fix: remove deprecated kotlinOptions DSL, incompatible with Gradle 9

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -35,11 +35,6 @@ kotlin {
     }
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = "$jvmTargetVer"
-    }
-}
 
 dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.7")                // https://plugins.gradle.org/plugin/com.github.spotbugs


### PR DESCRIPTION
The `kotlinOptions` DSL was deprecated in Kotlin Gradle Plugin in favour of `compilerOptions`. Gradle 9 promotes this deprecation to a build error.

The `kotlin { jvmToolchain { } }` block already sets the JVM target, making the `tasks.withType<KotlinCompile>` block redundant — so this PR simply removes it.

This unblocks the Dependabot Gradle wrapper bump to 9.x PR.