### PR TITLE
fix: add missing blank line in TopologyBuilder to fix spotless check

### DIFF
--- a/example-service/src/main/java/org/acme/example/example/service/kafka/streams/TopologyBuilder.java
+++ b/example-service/src/main/java/org/acme/example/example/service/kafka/streams/TopologyBuilder.java
@@ -65,6 +65,7 @@ public final class TopologyBuilder {
 
         return builder.build(ext.properties(DEFAULT_CLUSTER_NAME));
     }
+
     // formatting:off  init:remove
     private KeyValueMapper<String, Long, KeyValue<Long, String>>                    // init:remove
         switchKeyAndValue() {                                                       // init:remove


### PR DESCRIPTION
## Root Cause

The CI build was failing on the `spotlessJavaCheck` task for the `example-service` module.

`TopologyBuilder.java` was missing a blank line between the closing brace of the `build()` method and the `// formatting:off` comment immediately below it. Spotless enforces this blank line as part of its Java formatting rules.

## Fix

Added the missing blank line before the `// formatting:off  init:remove` comment in `TopologyBuilder.java` (line 68).

## Verification

The fix matches exactly what spotless reported as the required change in the build log:
```
@@ -65,6 +65,7 @@
     return builder.build(ext.properties(DEFAULT_CLUSTER_NAME));
 }
+
 // formatting:off  init:remove
```