### PR TITLE
chore: align buildSrc with Creek estate

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,7 +39,7 @@ kotlin {
 dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.7")                // https://plugins.gradle.org/plugin/com.github.spotbugs
     implementation("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
-    implementation("org.javamodularity:moduleplugin:2.0.0")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
+    implementation("org.javamodularity:moduleplugin:1.8.12")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("com.gradle.publish:plugin-publish-plugin:2.1.1")                        // https://plugins.gradle.org/plugin/com.gradle.plugin-publish
     implementation("org.creekservice:creek-system-test-gradle-plugin:0.4.1")                // https://plugins.gradle.org/plugin/org.creekservice.system.test
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,8 +38,8 @@ kotlin {
 
 dependencies {
     implementation("com.github.spotbugs.snom:spotbugs-gradle-plugin:6.0.7")                // https://plugins.gradle.org/plugin/com.github.spotbugs
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:7.2.1")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
-    implementation("org.javamodularity:moduleplugin:1.8.12")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
+    implementation("com.diffplug.spotless:spotless-plugin-gradle:8.4.0")                   // https://plugins.gradle.org/plugin/com.diffplug.spotless
+    implementation("org.javamodularity:moduleplugin:2.0.0")                                // https://plugins.gradle.org/plugin/org.javamodularity.moduleplugin
     implementation("com.gradle.publish:plugin-publish-plugin:2.1.1")                        // https://plugins.gradle.org/plugin/com.gradle.plugin-publish
     implementation("org.creekservice:creek-system-test-gradle-plugin:0.4.1")                // https://plugins.gradle.org/plugin/org.creekservice.system.test
 }

--- a/buildSrc/src/main/kotlin/common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-convention.gradle.kts
@@ -49,14 +49,6 @@ java {
 
 repositories {
     mavenCentral()
-
-    maven {
-        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-        mavenContent {
-            includeGroup("org.creekservice")
-            snapshotsOnly()
-        }
-    }
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-convention.gradle.kts
@@ -75,11 +75,7 @@ tasks.withType<JavaCompile> {
 }
 
 tasks.test {
-    useJUnitPlatform() {
-        if (project.hasProperty("excludeContainerised")) {
-            excludeTags("ContainerisedTest")
-        }
-    }
+    useJUnitPlatform()
 
     forkEvery = 5
     maxParallelForks = Runtime.getRuntime().availableProcessors()
@@ -162,3 +158,4 @@ tasks.test {
 
 // See: https://solidsoft.wordpress.com/2014/11/13/gradle-tricks-display-dependencies-for-all-subprojects-in-multi-project-build/
 tasks.register<DependencyReportTask>("allDeps") {}
+

--- a/buildSrc/src/main/kotlin/common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-convention.gradle.kts
@@ -19,12 +19,17 @@
  *
  * <p>Apply to all java modules, usually excluding the root project in multi-module sets.
  *
- * <p>Version: 1.7
+ * <p>Versions:
+ *  - 1.13: indentWithSpaces -> leadingTabsToSpaces and a few others
+ *  - 1.12: XML reporting for spotbugs
+ *  - 1.11: Add explicit checkstyle tool version
+ *  - 1.10: Add ability to exclude containerised tests
+ *  - 1.9: Add `allDeps` task.
+ *  - 1.8: Tweak test config to reduce build speed.
  *  - 1.7: Switch to setting Java version via toolchain
  *  - 1.6: Remove GitHub packages for snapshots
  *  - 1.5: Add filters to exclude generated sources
  *  - 1.4: Add findsecbugs-plugin
- *  - 1.3: Fail on warnings for test code too.
  */
 
 plugins {
@@ -44,15 +49,23 @@ java {
 
 repositories {
     mavenCentral()
+
+    maven {
+        url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        mavenContent {
+            includeGroup("org.creekservice")
+            snapshotsOnly()
+        }
+    }
 }
 
 dependencies {
-    spotbugsPlugins("com.h3xstream.findsecbugs:findsecbugs-plugin:1.12.0")
-    checkstyle("com.puppycrawl.tools:checkstyle:10.17.0")
+    spotbugsPlugins("com.h3xstream.findsecbugs:findsecbugs-plugin:1.14.0")
+    checkstyle("com.puppycrawl.tools:checkstyle:10.26.1")
 }
 
 configurations.all {
-    // Reduce chance of build servers running into compilation issues due to stale snapshots:
+    // Reduce the chance of build servers running into compilation issues due to stale snapshots:
     resolutionStrategy.cacheChangingModulesFor(15, TimeUnit.MINUTES)
 }
 
@@ -67,7 +80,8 @@ tasks.test {
             excludeTags("ContainerisedTest")
         }
     }
-    setForkEvery(5)
+
+    forkEvery = 5
     maxParallelForks = Runtime.getRuntime().availableProcessors()
     testLogging {
         showStandardStreams = true
@@ -81,7 +95,7 @@ tasks.test {
 spotless {
     java {
         googleJavaFormat("1.25.2").aosp().reflowLongStrings()
-        indentWithSpaces()
+        leadingTabsToSpaces()
         importOrder()
         removeUnusedImports()
         trimTrailingWhitespace()
@@ -95,15 +109,27 @@ spotbugs {
     excludeFilter.set(rootProject.file("config/spotbugs/suppressions.xml"))
 
     tasks.spotbugsMain {
-        reports.create("html") {
-            required.set(true)
-            setStylesheet("fancy-hist.xsl")
+        reports {
+            create("html") {
+                required.set(true)
+                setStylesheet("fancy-hist.xsl")
+            }
+
+            create("xml") {
+                required.set(true)
+            }
         }
     }
     tasks.spotbugsTest {
-        reports.create("html") {
-            required.set(true)
-            setStylesheet("fancy-hist.xsl")
+        reports {
+            create("html") {
+                required.set(true)
+                setStylesheet("fancy-hist.xsl")
+            }
+
+            create("xml") {
+                required.set(true)
+            }
         }
     }
 }
@@ -114,17 +140,25 @@ if (rootProject.name != project.name) {
     }
 }
 
-tasks.register("format") {
+val format = tasks.register("format") {
     group = "creek"
     description = "Format the code"
 
     dependsOn("spotlessCheck", "spotlessApply")
 }
 
-tasks.register("static") {
+val static = tasks.register("static") {
     group = "creek"
     description = "Run static code analysis"
 
     dependsOn("checkstyleMain", "checkstyleTest", "spotbugsMain", "spotbugsTest")
+
+    shouldRunAfter(format)
 }
 
+tasks.test {
+    shouldRunAfter(static)
+}
+
+// See: https://solidsoft.wordpress.com/2014/11/13/gradle-tricks-display-dependencies-for-all-subprojects-in-multi-project-build/
+tasks.register<DependencyReportTask>("allDeps") {}

--- a/buildSrc/src/main/kotlin/coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/coverage-convention.gradle.kts
@@ -17,7 +17,7 @@
 /**
  * Standard coverage configuration of Creek aggregates, utilising Jacoco and Codecov.
  *
- * <p>Version: 1.4
+ * <p>Version: 1.5
  *
  * <p>Apply to root project only
  */
@@ -25,8 +25,11 @@
 plugins {
     java
     jacoco
-    id("org.creekservice.system.test")
 }
+
+// Applied imperatively to avoid versionCatalogs conflict in generatePrecompiledScriptPluginAccessors
+// when using Gradle 8.1+ (where versionCatalogs became stable and is registered in synthetic projects)
+apply(plugin = "org.creekservice.system.test")
 
 repositories {
     mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Aligns buildSrc with the rest of the Creek estate:
- spotless-plugin-gradle 7.2.1 → 8.4.0 (where applicable)
- org.javamodularity:moduleplugin 1.8.x → 2.0.0 (where applicable)
- spotbugs-gradle-plugin updates (where applicable)
- Convention script alignment: findsecbugs, checkstyle version, forkEvery, spotbugs XML reports, shouldRunAfter task ordering, snapshot repo, group ID