### PR TITLE
chore: add coverage task

### DIFF
--- a/buildSrc/src/main/kotlin/coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/coverage-convention.gradle.kts
@@ -45,3 +45,9 @@ allprojects {
         }
     }
 }
+
+tasks.register("coverage") {
+    group = "creek"
+    description = "generate coverage report"
+    dependsOn("jacocoTestReport")
+}


### PR DESCRIPTION
Add `coverage` task to build file, matching change in creek-release-test#423.