### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/acme/example/api/ExampleAggregateDescriptor.java
+++ b/api/src/main/java/org/acme/example/api/ExampleAggregateDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/acme/example/internal/TopicConfigBuilder.java
+++ b/api/src/main/java/org/acme/example/internal/TopicConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/org/acme/example/internal/TopicDescriptors.java
+++ b/api/src/main/java/org/acme/example/internal/TopicDescriptors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/acme/example/api/ExampleAggregateDescriptorTest.java
+++ b/api/src/test/java/org/acme/example/api/ExampleAggregateDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/acme/example/internal/TopicConfigBuilderTest.java
+++ b/api/src/test/java/org/acme/example/internal/TopicConfigBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/acme/example/internal/TopicDescriptorsTest.java
+++ b/api/src/test/java/org/acme/example/internal/TopicDescriptorsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/common-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/common-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/coverage-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/coverage-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/module-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/module-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@
   <!-- Checks for Headers            init:remove                    -->
   <!-- See https://checkstyle.org/config_header.html  init:remove -->
   <module name="RegexpHeader">  <!-- init:remove -->
-    <property name="header" value="/\*\n\* Copyright (\d\d\d\d-)?2025 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/> <!-- init:remove -->
+    <property name="header" value="/\*\n\* Copyright (\d\d\d\d-)?2026 Creek Contributors \(https://github.com/creek-service\)$\n \*$\n \* Licensed under the Apache License, Version 2.0"/> <!-- init:remove -->
   </module> <!-- init:remove -->
 
   <module name="TreeWalker">

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/example-service/build.gradle.kts
+++ b/example-service/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example-service/include/log4j/log4j2.xml
+++ b/example-service/include/log4j/log4j2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+  ~ Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/example-service/src/main/java/org/acme/example/example/service/ServiceMain.java
+++ b/example-service/src/main/java/org/acme/example/example/service/ServiceMain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example-service/src/main/java/org/acme/example/example/service/kafka/streams/TopologyBuilder.java
+++ b/example-service/src/main/java/org/acme/example/example/service/kafka/streams/TopologyBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/example-service/src/test/java/org/acme/example/example/streams/TopologyBuilderTest.java
+++ b/example-service/src/test/java/org/acme/example/example/streams/TopologyBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/services/build.gradle.kts
+++ b/services/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/services/src/main/java/module-info.java
+++ b/services/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/services/src/main/java/org/acme/example/services/ExampleServiceDescriptor.java
+++ b/services/src/main/java/org/acme/example/services/ExampleServiceDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2021-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/services/src/main/java/org/acme/example/services/Keep.java
+++ b/services/src/main/java/org/acme/example/services/Keep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/services/src/test/java/org/acme/example/services/ExampleServiceDescriptorTest.java
+++ b/services/src/test/java/org/acme/example/services/ExampleServiceDescriptorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2023-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/system-tests/build.gradle.kts
+++ b/system-tests/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2025 Creek Contributors (https://github.com/creek-service)
+ * Copyright 2022-2026 Creek Contributors (https://github.com/creek-service)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update checkstyle header rule and existing copyright headers from 2025 to 2026.